### PR TITLE
Add support for building particular prysm version from source.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ ethv_validator_keys_folder: "validator_keys"
 # If not built from source, the official prysm.sh installer is used
 ethv_prysm_build_from_source: no
 
+# Only used when building from source as prysm.sh pulls latest binaries
+ethv_prysm_release_version: "v1.0.1"
+
 # Path to the beacon-chain binary
 ethv_prysm_beacon_chain_binary: "/usr/local/bin/beacon-chain"
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ ethv_validator_keys_folder: "validator_keys"
 ethv_prysm_build_from_source: no
 
 # Only used when building from source as prysm.sh pulls latest binaries
-ethv_prysm_release_version: "v1.0.1"
+ethv_prysm_release_version: ""
 
 # Path to the beacon-chain binary
 ethv_prysm_beacon_chain_binary: "/usr/local/bin/beacon-chain"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,7 +41,7 @@ ethv_validator_keys_folder: "validator_keys"
 ethv_prysm_build_from_source: no
 
 # Only used when building from source as prysm.sh pulls latest binaries
-ethv_prysm_release_version: "v1.0.1"
+ethv_prysm_release_version: ""
 
 # Path to the beacon-chain binary
 ethv_prysm_beacon_chain_binary: "/usr/local/bin/beacon-chain"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,9 @@ ethv_validator_keys_folder: "validator_keys"
 # If not built from source, the official prysm.sh installer is used
 ethv_prysm_build_from_source: no
 
+# Only used when building from source as prysm.sh pulls latest binaries
+ethv_prysm_release_version: "v1.0.1"
+
 # Path to the beacon-chain binary
 ethv_prysm_beacon_chain_binary: "/usr/local/bin/beacon-chain"
 

--- a/tasks/04_setup_prysm.yml
+++ b/tasks/04_setup_prysm.yml
@@ -78,7 +78,7 @@
     git:
       repo: "https://github.com/prysmaticlabs/prysm"
       dest: /srv/prysm
-      version: "{{ethv_prysm_release_version}}"
+      version: "{{ ethv_prysm_release_version | default('master') }}"
 
   - name: Build beacon-chain
     command:

--- a/tasks/04_setup_prysm.yml
+++ b/tasks/04_setup_prysm.yml
@@ -78,6 +78,7 @@
     git:
       repo: "https://github.com/prysmaticlabs/prysm"
       dest: /srv/prysm
+      version: "{{ethv_prysm_release_version}}"
 
   - name: Build beacon-chain
     command:

--- a/templates/prysm-validator.service.j2
+++ b/templates/prysm-validator.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=Validator
+Description=Prysm Validator
 Wants=network-online.target
 After=network-online.target
 


### PR DESCRIPTION
This is done by adding the `ethv_prysm_release_version` variable