### PR TITLE
Enable opting in to monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,22 @@ ethv_wallet_password: "eth2.0-deposit-cli"
 # String to include in proposed blocks
 ethv_graffiti: "helloitsme"
 
+# Name of the validator_keys folder in files/ - useful if you test with multiple different ones
+ethv_validator_keys_folder: "validator_keys"
+
+# Reboot after update
+ethv_reboot_after_update: yes
+
+#
+# Monitoring
+#
+
+# Enable monitoring
+ethv_monitoring: no
+
+# Expose monitoring through the firewall
+ethv_monitoring_expose: no
+
 # Grafana admin password
 ethv_grafana_admin_password: "admin"
 
@@ -152,12 +168,6 @@ ethv_grafana_smtp_user: ""
 
 # Grafana Mail notification smtp password
 ethv_grafana_smtp_password: ""
-
-# Name of the validator_keys folder in files/ - useful if you test with multiple different ones
-ethv_validator_keys_folder: "validator_keys"
-
-# Reboot after update
-ethv_reboot_after_update: yes
 
 #
 # Prysm eth2.0 client specific - https://github.com/prysmaticlabs/prysm

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -40,6 +40,22 @@ ethv_wallet_password: "eth2.0-deposit-cli"
 # String to include in proposed blocks
 ethv_graffiti: "helloitsme"
 
+# Name of the validator_keys folder in files/ - useful if you test with multiple different ones
+ethv_validator_keys_folder: "validator_keys"
+
+# Reboot after update
+ethv_reboot_after_update: yes
+
+#
+# Monitoring
+#
+
+# Enable monitoring
+ethv_monitoring: no
+
+# Expose monitoring through the firewall
+ethv_monitoring_expose: no
+
 # Grafana admin password
 ethv_grafana_admin_password: "admin"
 
@@ -66,12 +82,6 @@ ethv_grafana_smtp_user: ""
 
 # Grafana Mail notification smtp password
 ethv_grafana_smtp_password: ""
-
-# Name of the validator_keys folder in files/ - useful if you test with multiple different ones
-ethv_validator_keys_folder: "validator_keys"
-
-# Reboot after update
-ethv_reboot_after_update: yes
 
 #
 # Prysm eth2.0 client specific - https://github.com/prysmaticlabs/prysm

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -6,6 +6,7 @@
     ethv_20_net: pyrmont
     ethv_validator_keys_folder: validator_keys_testing
     ethv_prysm_pre_start_delay: 13
+    ethv_monitoring: yes
   tasks:
     - name: "Include ethereum-validator"
       include_role:

--- a/tasks/01_setup_firewall.yml
+++ b/tasks/01_setup_firewall.yml
@@ -46,3 +46,6 @@
     rule: allow
     port: '{{ ethv_grafana_port }}'
     proto: tcp
+  when:
+    - ethv_monitoring
+    - ethv_monitoring_expose

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -15,17 +15,20 @@
 - name: Setup Prysm
   import_tasks: 04_setup_prysm.yml
 
-- name: Setup Prometheus
-  import_tasks: 05_setup_prometheus.yml
+- name: Setup Monitoring
+  block:
+    - name: Setup Prometheus
+      import_tasks: 05_setup_prometheus.yml
 
-- name: Setup Node Exporter
-  import_tasks: 06_setup_node_exporter.yml
+    - name: Setup Node Exporter
+      import_tasks: 06_setup_node_exporter.yml
 
-- name: Setup JSON Exporter
-  import_tasks: 06_setup_json_exporter.yml
+    - name: Setup JSON Exporter
+      import_tasks: 06_setup_json_exporter.yml
 
-- name: Setup Blackbox Exporter
-  import_tasks: 06_setup_blackbox_exporter.yml
+    - name: Setup Blackbox Exporter
+      import_tasks: 06_setup_blackbox_exporter.yml
 
-- name: Setup Grafana
-  import_tasks: 07_setup_grafana.yml
+    - name: Setup Grafana
+      import_tasks: 07_setup_grafana.yml
+  when: ethv_monitoring


### PR DESCRIPTION
Monitoring requires a secure setup, which is up to the user in the end
and cannot be fully treated by this ansible role.

The default setup is not secure, so enable the user to opt-in